### PR TITLE
Winkelgebieden

### DIFF
--- a/winkelgebieden/winkelgebieden.json
+++ b/winkelgebieden/winkelgebieden.json
@@ -1,114 +1,57 @@
 {
   "type": "dataset",
-  "id": "fietspaaltjes",
-  "title": "fietspaaltjes",
+  "id": "winkgebieden",
+  "title": "winkgebieden",
   "status": "beschikbaar",
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "tables": [
     {
-      "id": "fietspaaltjes",
+      "id": "geb",
       "type": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "additionalProperties": false,
-        "required": ["schema", "id"],
+        "required": ["schema", "ogc fid"],
         "display": "id",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "id": {
+          "ogc fid": {
             "type": "string"
           },
-          "geometry": {
+          "wkb geometry": {
             "$ref": "https://geojson.org/schema/Geometry.json"
           },
-          "street": {
+          "gebcode": {
             "type": "string"
           },
-          "at": {
+          "gebnaam": {
             "type": "string"
           },
-          "area": {
+          "code": {
             "type": "string"
           },
-          "score 2013": {
+          "oppha": {
+            "type": "number"
+          },
+          "codewg": {
             "type": "string"
           },
-          "score current": {
+          "concnaam": {
             "type": "string"
           },
-          "count": {
-            "type": "integer"
+          "geb22": {
+            "type": "string"                      
           },
-          "paaltjes weg": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+         "categorie": {
+            "type": "string"
           },
-          "soort paaltje": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "uiterlijk": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "type": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "ruimte": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "markering": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "beschadigingen": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "veiligheid": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "zicht in donker": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "soort weg": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "noodzaak": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
+          "categorie naam": {
+            "type": "string"
+          }         
         }
       }
     }

--- a/winkelgebieden/winkelgebieden.json
+++ b/winkelgebieden/winkelgebieden.json
@@ -22,7 +22,7 @@
           "id": {
             "type": "string"
           },
-          "wkbgeometry": {
+          "wkb geometry": {
             "$ref": "https://geojson.org/schema/Geometry.json"
           },
           "gebcode": {

--- a/winkelgebieden/winkelgebieden.json
+++ b/winkelgebieden/winkelgebieden.json
@@ -3,7 +3,7 @@
   "id": "winkgeb",
   "title": "winkgeb",
   "status": "beschikbaar",
-  "description": 'Winkelgebieden',
+  "description": "Winkelgebieden",
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "tables": [

--- a/winkelgebieden/winkelgebieden.json
+++ b/winkelgebieden/winkelgebieden.json
@@ -3,7 +3,7 @@
   "id": "winkgeb",
   "title": "winkgeb",
   "status": "beschikbaar",
-  "description": null,
+  "description": 'Winkelgebieden',
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "tables": [

--- a/winkelgebieden/winkelgebieden.json
+++ b/winkelgebieden/winkelgebieden.json
@@ -1,113 +1,66 @@
 {
   "type": "dataset",
-  "id": "fietspaaltjes",
-  "title": "fietspaaltjes",
+  "id": "winkgeb",
+  "title": "winkgeb",
   "status": "beschikbaar",
+  "description": "winkelgebieden",
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "tables": [
     {
-      "id": "fietspaaltjes",
+      "id": "geb",
       "type": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "additionalProperties": false,
-        "required": ["schema", "id"],
+        "required": [
+          "schema",
+          "ogc fid"
+        ],
         "display": "id",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "id": {
-            "type": "string"
-          },
-          "geometry": {
-            "$ref": "https://geojson.org/schema/Geometry.json"
-          },
-          "street": {
-            "type": "string"
-          },
-          "at": {
-            "type": "string"
-          },
-          "area": {
-            "type": "string"
-          },
-          "score 2013": {
-            "type": "string"
-          },
-          "score current": {
-            "type": "string"
-          },
-          "count": {
+          "ogc fid": {
             "type": "integer"
           },
-          "paaltjes weg": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "wkb geometry": {
+            "$ref": "https://geojson.org/schema/Geometry.json"
           },
-          "soort paaltje": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "gebcode": {
+            "type": "string"
           },
-          "uiterlijk": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "gebnaam": {
+            "type": "string"
           },
-          "type": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "code": {
+            "type": "string"
           },
-          "ruimte": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "oppha": {
+            "type": "number"
           },
-          "markering": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "codewg": {
+            "type": "string"
           },
-          "beschadigingen": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "concgebied": {
+            "type": "string"
           },
-          "veiligheid": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "concnaam": {
+            "type": "string"
           },
-          "zicht in donker": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "bc2015": {
+            "type": "string"
           },
-          "soort weg": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "geb22": {
+            "type": "string"
           },
-          "noodzaak": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
+          "categorie": {
+            "type": "string"
+          },
+          "categorie naam": {
+            "type": "string"
           }
         }
       }

--- a/winkelgebieden/winkelgebieden.json
+++ b/winkelgebieden/winkelgebieden.json
@@ -16,14 +16,14 @@
         "additionalProperties": false,
         "required": [
           "schema",
-          "ogc fid"
+          "ogc_fid"
         ],
         "display": "id",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "ogc fid": {
+          "ogc_fid": {
             "type": "integer"
           },
           "wkb geometry": {

--- a/winkelgebieden/winkelgebieden.json
+++ b/winkelgebieden/winkelgebieden.json
@@ -1,63 +1,113 @@
 {
   "type": "dataset",
-  "id": "winkgeb",
-  "title": "winkgeb",
+  "id": "fietspaaltjes",
+  "title": "fietspaaltjes",
   "status": "beschikbaar",
-  "description": "winkelgebieden",
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "tables": [
     {
-      "id": "geb",
+      "id": "fietspaaltjes",
       "type": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "additionalProperties": false,
-        "required": ["schema","ogc_fid"],
+        "required": ["schema", "id"],
         "display": "id",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "ogc_fid": {
-            "type": "integer"
+          "id": {
+            "type": "string"
           },
-          "wkb geometry": {
+          "geometry": {
             "$ref": "https://geojson.org/schema/Geometry.json"
           },
-          "gebcode": {
+          "street": {
             "type": "string"
           },
-          "gebnaam": {
+          "at": {
             "type": "string"
           },
-          "code": {
+          "area": {
             "type": "string"
           },
-          "oppha": {
-            "type": "number"
-          },
-          "codewg": {
+          "score 2013": {
             "type": "string"
           },
-          "concgebied": {
+          "score current": {
             "type": "string"
           },
-          "concnaam": {
-            "type": "string"
+          "count": {
+            "type": "integer"
           },
-          "bc2015": {
-            "type": "string"
+          "paaltjes weg": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
-          "geb22": {
-            "type": "string"
+          "soort paaltje": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
-          "categorie": {
-            "type": "string"
+          "uiterlijk": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
-          "categorie naam": {
-            "type": "string"
+          "type": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "ruimte": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "markering": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "beschadigingen": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "veiligheid": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "zicht in donker": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "soort weg": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "noodzaak": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       }

--- a/winkelgebieden/winkelgebieden.json
+++ b/winkelgebieden/winkelgebieden.json
@@ -1,8 +1,9 @@
 {
   "type": "dataset",
-  "id": "winkgebieden",
-  "title": "winkgebieden",
+  "id": "winkgeb",
+  "title": "winkgeb",
   "status": "beschikbaar",
+  "description": null,
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "tables": [
@@ -13,14 +14,17 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "additionalProperties": false,
-        "required": ["schema", "id"],
+        "required": [
+          "schema",
+          "id"
+        ],
         "display": "id",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
           "id": {
-            "type": "string"
+            "type": "integer"
           },
           "wkb geometry": {
             "$ref": "https://geojson.org/schema/Geometry.json"
@@ -40,18 +44,24 @@
           "codewg": {
             "type": "string"
           },
+          "concgebied": {
+            "type": "string"
+          },
           "concnaam": {
             "type": "string"
           },
+          "bc2015": {
+            "type": "string"
+          },
           "geb22": {
-            "type": "string"                      
-          },
-         "categorie": {
             "type": "string"
           },
-          "categorienaam": {
+          "categorie": {
             "type": "string"
-          }         
+          },
+          "categorie naam": {
+            "type": "string"
+          }
         }
       }
     }

--- a/winkelgebieden/winkelgebieden.json
+++ b/winkelgebieden/winkelgebieden.json
@@ -1,66 +1,113 @@
 {
   "type": "dataset",
-  "id": "winkgeb",
-  "title": "winkgeb",
+  "id": "fietspaaltjes",
+  "title": "fietspaaltjes",
   "status": "beschikbaar",
-  "description": "winkelgebieden",
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "tables": [
     {
-      "id": "geb",
+      "id": "fietspaaltjes",
       "type": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "additionalProperties": false,
-        "required": [
-          "schema",
-          "ogc fid"
-        ],
+        "required": ["schema", "id"],
         "display": "id",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "ogc fid": {
-            "type": "integer"
+          "id": {
+            "type": "string"
           },
-          "wkb geometry": {
+          "geometry": {
             "$ref": "https://geojson.org/schema/Geometry.json"
           },
-          "gebcode": {
+          "street": {
             "type": "string"
           },
-          "gebnaam": {
+          "at": {
             "type": "string"
           },
-          "code": {
+          "area": {
             "type": "string"
           },
-          "oppha": {
-            "type": "number"
-          },
-          "codewg": {
+          "score 2013": {
             "type": "string"
           },
-          "concgebied": {
+          "score current": {
             "type": "string"
           },
-          "concnaam": {
-            "type": "string"
+          "count": {
+            "type": "integer"
           },
-          "bc2015": {
-            "type": "string"
+          "paaltjes weg": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
-          "geb22": {
-            "type": "string"
+          "soort paaltje": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
-          "categorie": {
-            "type": "string"
+          "uiterlijk": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
-          "categorie naam": {
-            "type": "string"
+          "type": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "ruimte": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "markering": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "beschadigingen": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "veiligheid": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "zicht in donker": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "soort weg": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "noodzaak": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         }
       }

--- a/winkelgebieden/winkelgebieden.json
+++ b/winkelgebieden/winkelgebieden.json
@@ -13,13 +13,13 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "additionalProperties": false,
-        "required": ["schema", "ogcfid"],
+        "required": ["schema", "id"],
         "display": "id",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "ogcfid": {
+          "id": {
             "type": "string"
           },
           "wkbgeometry": {

--- a/winkelgebieden/winkelgebieden.json
+++ b/winkelgebieden/winkelgebieden.json
@@ -13,16 +13,16 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "additionalProperties": false,
-        "required": ["schema", "ogc fid"],
+        "required": ["schema", "ogcfid"],
         "display": "id",
         "properties": {
           "schema": {
             "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
           },
-          "ogc fid": {
+          "ogcfid": {
             "type": "string"
           },
-          "wkb geometry": {
+          "wkbgeometry": {
             "$ref": "https://geojson.org/schema/Geometry.json"
           },
           "gebcode": {
@@ -49,7 +49,7 @@
          "categorie": {
             "type": "string"
           },
-          "categorie naam": {
+          "categorienaam": {
             "type": "string"
           }         
         }

--- a/winkelgebieden/winkelgebieden.json
+++ b/winkelgebieden/winkelgebieden.json
@@ -1,0 +1,69 @@
+{
+  "type": "dataset",
+  "id": "winkgeb",
+  "title": "winkgeb",
+  "status": "beschikbaar",
+  "description": "winkelgebieden",
+  "version": "0.0.1",
+  "crs": "EPSG:28992",
+  "tables": [
+    {
+      "id": "geb",
+      "type": "table",
+      "schema": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "schema",
+          "ogc fid"
+        ],
+        "display": "id",
+        "properties": {
+          "schema": {
+            "$ref": "https://schemas.data.amsterdam.nl/schema@v1.1.1#/definitions/schema"
+          },
+          "ogc fid": {
+            "type": "integer"
+          },
+          "wkb geometry": {
+            "$ref": "https://geojson.org/schema/Geometry.json"
+          },
+          "gebcode": {
+            "type": "string"
+          },
+          "gebnaam": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          },
+          "oppha": {
+            "type": "number"
+          },
+          "codewg": {
+            "type": "string"
+          },
+          "concgebied": {
+            "type": "string"
+          },
+          "concnaam": {
+            "type": "string"
+          },
+          "bc2015": {
+            "type": "string"
+          },
+          "geb22": {
+            "type": "string"
+          },
+          "categorie": {
+            "type": "string"
+          },
+          "categorie naam": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/winkelgebieden/winkelgebieden.json
+++ b/winkelgebieden/winkelgebieden.json
@@ -14,10 +14,7 @@
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "additionalProperties": false,
-        "required": [
-          "schema",
-          "ogc_fid"
-        ],
+        "required": ["schema","ogc_fid"],
         "display": "id",
         "properties": {
           "schema": {


### PR DESCRIPTION
Winkelgebieden: added JSON schema conform validation rules Amsterdam schema

Based on the database structure of the dataset Winkelgebieden - which is one of the VSD sets - a data schema was generated. The generation of the schema was done by the introspect method of the amsterdam-schema-tools (part of the pypi lib). Some additional adjustments where made after generation like the submission of the description of the dateset itself. This could be omitted but cannot have a null value if exists. Furthermore there is one attribute defined where there is a space in the name => 'wkb geometry'. No adjustments where made to this name like replacing the space by an underscore.