### PR TITLE
Winkelgebieden: Changed dataset id and table id to "winkelgebieden"

### DIFF
--- a/winkelgebieden/winkelgebieden.json
+++ b/winkelgebieden/winkelgebieden.json
@@ -1,23 +1,20 @@
 {
   "type": "dataset",
-  "id": "winkgeb",
-  "title": "winkgeb",
+  "id": "winkelgebieden",
+  "title": "winkelgebieden",
   "status": "beschikbaar",
   "description": "Winkelgebieden",
   "version": "0.0.1",
   "crs": "EPSG:28992",
   "tables": [
     {
-      "id": "geb",
+      "id": "winkelgebieden",
       "type": "table",
       "schema": {
         "$schema": "http://json-schema.org/draft-07/schema#",
         "type": "object",
         "additionalProperties": false,
-        "required": [
-          "schema",
-          "id"
-        ],
+        "required": ["schema", "id"],
         "display": "id",
         "properties": {
           "schema": {


### PR DESCRIPTION
To comply on the naming conventions, the winkelgebieden is adjusted so the dataset id and table id are the same and not condemned.