### PR TITLE
winkelgebieden: renamed wkb geometry to geometry

### DIFF
--- a/winkelgebieden/winkelgebieden.json
+++ b/winkelgebieden/winkelgebieden.json
@@ -23,7 +23,7 @@
           "id": {
             "type": "integer"
           },
-          "wkb geometry": {
+          "geometry": {
             "$ref": "https://geojson.org/schema/Geometry.json"
           },
           "gebcode": {


### PR DESCRIPTION
The location data in DSO API's are namend geometry.
To be complied with the naming conventions the attribute name is changed.