### PR TITLE
Blackspots use date types

### DIFF
--- a/blackspots/blackspots.json
+++ b/blackspots/blackspots.json
@@ -4,7 +4,7 @@
   "title": "blackspots",
   "status": "beschikbaar",
   "description": "Blackspots",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "crs": "EPSG:28992",
   "tables": [
     {

--- a/blackspots/blackspots.json
+++ b/blackspots/blackspots.json
@@ -56,9 +56,17 @@
             "type": "string"
           },
           "start uitvoering": {
-            "type": "string"
+            "type": "string",
+            "format": "date"
           },
           "eind uitvoering": {
+            "type": "string",
+            "format": "date"
+          },
+          "start opmerking": {
+            "type": "string"
+          },
+          "eind opmerking": {
             "type": "string"
           },
           "jaar blackspotlijst": {

--- a/blackspots/blackspots.json
+++ b/blackspots/blackspots.json
@@ -4,6 +4,7 @@
   "title": "blackspots",
   "status": "beschikbaar",
   "description": "Blackspots",
+  "auth": "FP/MDW",
   "version": "0.0.2",
   "crs": "EPSG:28992",
   "tables": [

--- a/blackspots/blackspots.json
+++ b/blackspots/blackspots.json
@@ -6,7 +6,7 @@
   "description": "Blackspots",
   "auth": "FP/MDW",
   "version": "0.0.2",
-  "crs": "EPSG:28992",
+  "crs": "EPSG:4326",
   "tables": [
     {
       "id": "blackspots",


### PR DESCRIPTION
Blackspots was using strings to store dates. However, sometimes, non-date values were used.
For these non-date values, new field have been introduced.