### PR TITLE
WIP. Versioning definition.

### DIFF
--- a/bagh/bagh.json
+++ b/bagh/bagh.json
@@ -10,7 +10,7 @@
     "version_field_name": "volgnummer",
     "pk_field_name": "identificatie",
     "temporal": {
-      "geldigOp": ["begin_geldigheid", "eind_geldigheid"]
+      "geldigOp": ["begin geldigheid", "eind geldigheid"]
     }
   },
   "tables": [

--- a/bagh/bagh.json
+++ b/bagh/bagh.json
@@ -5,6 +5,14 @@
   "status": "beschikbaar",
   "version": "0.0.1",
   "crs": "EPSG:28992",
+  "versioning": {
+    "request_parameter": "versie",
+    "version_field_name": "volgnummer",
+    "pk_field_name": "identificatie",
+    "temporal": {
+      "geldigOp": ["begin_geldigheid", "eind_geldigheid"]
+    }
+  },
   "tables": [
     {
       "id": "bouwblok",


### PR DESCRIPTION
Dit is een voorbeeld van `versioning` binnen een schema.

Deze moet op schema niveau gezet worden.

# Versioning

* `request_parameter`: GET parameter die gebruikt om versie te bepaalen (kan wel weggegooid worden en dan blijft `versie` default)
* `version_field_name`: Schema veld naam die behoudt object versie. Optioneel, in het gevaalen wanneer die niet gezet is - wordt `versie` niet gebruikt.
* `pk_field_name`: Schema veld naam die behoudt object ID, moet gezet worden samen met `version_field_name`.

# Temporal filtering:

Er is een extra array gedefineerd met een of meerdere datum/tijd definities.

* `temporal` is een optionele definitie met datum/tijd afhankelijke velden

Voorbeeld: 

```
"geldigOp": ["begin geldigheid", "eind geldigheid"]
```

Zorgdt dat request met `?geldigOp=...` parameter heeft alleen objecten waar gewenste `geldigOp` is tussen `begin geldigheid` en `eind geldigheid`.